### PR TITLE
feat: configure retries and increase grace period

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ This actions achieve this with minimal noise (no comment bloat) by adding a labe
 
 **Required** Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}
 
+### `retryAfter`
+
+Number of seconds after which the mergable state is checked again if it is unknown (GitHub is still calculating it).
+
+**Default**: 120
+
+### `retryMax`
+
+Number of times the script will check the mergable state aigain. After that it will print a warning.
+
+**Default**: 5
+
 ## Example usage
 
 ```yaml
@@ -37,7 +49,7 @@ on:
   push:
   # So that the `dirtyLabel` is removed if conflicts are resolved
   # WARNING: PRs from forks don't have access to screts.
-  # You might want to skip this action on pull_requests which means 
+  # You might want to skip this action on pull_requests which means
   # the label might not reflect the current state of the PR until
   # another push on `master`
   pull_request:

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   removeOnDirtyLabel:
     description: "Name of the label which should be removed"
     required: true
+  retryAfter:
+    description: "Number of seconds after which the action runs again if the mergable state is unknown."
+  retryMax:
+    description: "Number of times the action retries calculating the mergable state"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -8649,20 +8649,23 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
 function main() {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         const repoToken = core.getInput("repoToken", { required: true });
         const dirtyLabel = core.getInput("dirtyLabel", { required: true });
         const removeOnDirtyLabel = core.getInput("removeOnDirtyLabel", {
             required: true
         });
+        const retryAfter = parseInt((_a = core.getInput("retryAfter")) !== null && _a !== void 0 ? _a : 120, 10);
+        const retryMax = parseInt((_b = core.getInput("retryMax")) !== null && _b !== void 0 ? _b : 5, 10);
         const client = new github.GitHub(repoToken);
         return yield checkDirty({
             client,
             dirtyLabel,
             removeOnDirtyLabel,
             after: null,
-            retryAfter: 60,
-            retryMax: 3
+            retryAfter,
+            retryMax
         });
     });
 }

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -7,6 +7,8 @@ async function main() {
 	const removeOnDirtyLabel = core.getInput("removeOnDirtyLabel", {
 		required: true
 	});
+	const retryAfter = parseInt(core.getInput("retryAfter") ?? 120, 10);
+	const retryMax = parseInt(core.getInput("retryMax") ?? 5, 10);
 
 	const client = new github.GitHub(repoToken);
 
@@ -15,8 +17,8 @@ async function main() {
 		dirtyLabel,
 		removeOnDirtyLabel,
 		after: null,
-		retryAfter: 60,
-		retryMax: 3
+		retryAfter,
+		retryMax
 	});
 }
 


### PR DESCRIPTION
Retries after 120s (up from 60s) for 5 times (up from 3) and makes these numbers configurable. The current grace period turned out to be to short for Material-UI.