### PR TITLE
fix: default values for retry* being ignored

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8649,15 +8649,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
 function main() {
-    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         const repoToken = core.getInput("repoToken", { required: true });
         const dirtyLabel = core.getInput("dirtyLabel", { required: true });
         const removeOnDirtyLabel = core.getInput("removeOnDirtyLabel", {
             required: true
         });
-        const retryAfter = parseInt((_a = core.getInput("retryAfter")) !== null && _a !== void 0 ? _a : 120, 10);
-        const retryMax = parseInt((_b = core.getInput("retryMax")) !== null && _b !== void 0 ? _b : 5, 10);
+        const retryAfter = parseInt(core.getInput("retryAfter") || "120", 10);
+        const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
         const client = new github.GitHub(repoToken);
         return yield checkDirty({
             client,

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -7,7 +7,6 @@ async function main() {
 	const removeOnDirtyLabel = core.getInput("removeOnDirtyLabel", {
 		required: true
 	});
-
 	const retryAfter = parseInt(core.getInput("retryAfter") || "120", 10);
 	const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
 

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -7,8 +7,9 @@ async function main() {
 	const removeOnDirtyLabel = core.getInput("removeOnDirtyLabel", {
 		required: true
 	});
-	const retryAfter = parseInt(core.getInput("retryAfter") ?? 120, 10);
-	const retryMax = parseInt(core.getInput("retryMax") ?? 5, 10);
+
+	const retryAfter = parseInt(core.getInput("retryAfter") || "120", 10);
+	const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
 
 	const client = new github.GitHub(repoToken);
 


### PR DESCRIPTION
If inputs aren't provided you get an empty string instead of nullish.