### PR TITLE
fix: don't add label if it already exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test (PR)
         # Add your repository and branch here to test your changes
         # e.g. eps1lon/actions-label-merge-conflict@feat/retry-unknown
-        uses: eps1lon/actions-label-merge-conflict@fix/update-too-often
+        uses: ./
         with:
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test (PR)
         # Add your repository and branch here to test your changes
         # e.g. eps1lon/actions-label-merge-conflict@feat/retry-unknown
-        uses: ./
+        uses: eps1lon/actions-label-merge-conflict@fix/update-too-often
         with:
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"

--- a/dist/index.js
+++ b/dist/index.js
@@ -8758,9 +8758,11 @@ function addLabelIfNotExists(label, { number }, { client }) {
             repo: github.context.repo.repo,
             issue_number: number
         });
+        core.debug(JSON.stringify(issue, null, 2));
         const hasLabel = issue.labels.find(issueLabel => {
             return issueLabel.name === label;
         }) !== undefined;
+        core.info(`Issue #${number} already has label '${label}'. Skipping.`);
         if (hasLabel) {
             return;
         }

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -156,10 +156,14 @@ async function addLabelIfNotExists(
 		issue_number: number
 	});
 
+	core.debug(JSON.stringify(issue, null, 2));
+
 	const hasLabel =
 		issue.labels.find(issueLabel => {
 			return issueLabel.name === label;
 		}) !== undefined;
+
+	core.info(`Issue #${number} already has label '${label}'. Skipping.`);
 
 	if (hasLabel) {
 		return;

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -106,7 +106,7 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
 				info(`add "${dirtyLabel}", remove "${removeOnDirtyLabel}"`);
 				// for labels PRs and issues are the same
 				await Promise.all([
-					addLabel(dirtyLabel, pullRequest, { client }),
+					addLabelIfNotExists(dirtyLabel, pullRequest, { client }),
 					removeLabelIfExists(removeOnDirtyLabel, pullRequest, { client })
 				]);
 				break;
@@ -142,12 +142,30 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
 	}
 }
 
-function addLabel(
+/**
+ * Assumes that the issue exists
+ */
+async function addLabelIfNotExists(
 	label: string,
 	{ number }: { number: number },
 	{ client }: { client: github.GitHub }
 ) {
-	return client.issues
+	const { data: issue } = await client.issues.get({
+		owner: github.context.repo.owner,
+		repo: github.context.repo.repo,
+		issue_number: number
+	});
+
+	const hasLabel =
+		issue.labels.find(issueLabel => {
+			return issueLabel.name === label;
+		}) !== undefined;
+
+	if (hasLabel) {
+		return;
+	}
+
+	await client.issues
 		.addLabels({
 			owner: github.context.repo.owner,
 			repo: github.context.repo.repo,


### PR DESCRIPTION
Adding a label always marks the PR as updated even if the label already exist. This is quite annoying since they're not updated in a meaningful way. Therefore we only add the label if it does not exist.