### PR TITLE
feat: Allow warning only if secrets aren't available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./
         with:
           # pull_requests don't have access to secrets
-          continueOnMissingPermissions: "${{ github.action == 'synchronize' }}"
+          continueOnMissingPermissions: "${{ github.event.action == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
@@ -42,7 +42,7 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@main
         with:
           # pull_requests don't have access to secrets
-          continueOnMissingPermissions: "${{ github.action == 'synchronize' }}"
+          continueOnMissingPermissions: "${{ github.event.action == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         # e.g. eps1lon/actions-label-merge-conflict@feat/retry-unknown
         uses: ./
         with:
+          # pull_requests don't have access to secrets
           continueOnMissingPermissions: "${{ github.action == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
@@ -40,6 +41,7 @@ jobs:
       - name: Test
         uses: eps1lon/actions-label-merge-conflict@main
         with:
+          # pull_requests don't have access to secrets
           continueOnMissingPermissions: "${{ github.action == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,14 @@ jobs:
         # e.g. eps1lon/actions-label-merge-conflict@feat/retry-unknown
         uses: ./
         with:
-          continueOnMissingPermissions: "${{ github.event.name === 'synchronize' }}"
+          continueOnMissingPermissions: "${{ github.event.name == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Test
         uses: eps1lon/actions-label-merge-conflict@main
         with:
-          continueOnMissingPermissions: "${{ github.event.name === 'synchronize' }}"
+          continueOnMissingPermissions: "${{ github.event.name == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - uses: hmarr/debug-action@master
       - name: checkout
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -32,13 +33,14 @@ jobs:
         # e.g. eps1lon/actions-label-merge-conflict@feat/retry-unknown
         uses: ./
         with:
+          continueOnMissingPermissions: "${{ github.event.name === 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Test
         uses: eps1lon/actions-label-merge-conflict@main
         with:
+          continueOnMissingPermissions: "${{ github.event.name === 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          continueOnMissingPermissions: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,14 @@ jobs:
         # e.g. eps1lon/actions-label-merge-conflict@feat/retry-unknown
         uses: ./
         with:
-          continueOnMissingPermissions: "${{ github.event.name == 'synchronize' }}"
+          continueOnMissingPermissions: "${{ github.action == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Test
         uses: eps1lon/actions-label-merge-conflict@main
         with:
-          continueOnMissingPermissions: "${{ github.event.name == 'synchronize' }}"
+          continueOnMissingPermissions: "${{ github.action == 'synchronize' }}"
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,4 @@ jobs:
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          continueOnMissingPermissions: true

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Number of times the script will check the mergable state aigain. After that it w
 
 **Default**: 5
 
+### `continueOnMissingPermissions`
+
+Boolean. Whether to continue or fail when the provided token is missing permissions. By default pull requests from a fork do not have access to secrets and get a read only github token, resulting in a failure to update tags.
+
+**Default**: false
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ inputs:
     description: "Number of seconds after which the action runs again if the mergable state is unknown."
   retryMax:
     description: "Number of times the action retries calculating the mergable state"
+  continueOnMissingPermissions:
+    description: "Boolean. Whether to continue or fail when the provided token is missing permissions. By default pull requests from a fork do not have access to secrets and get a read only github token, resulting in a failure to update tags."
 ouputs:
   prDirtyStatuses:
     description: "Object-map. The keys are pull request numbers and their values whether a PR is dirty or not."

--- a/dist/index.js
+++ b/dist/index.js
@@ -7587,6 +7587,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
 const prDirtyStatusesOutputKey = `prDirtyStatuses`;
+const commonErrorDetailedMessage = `Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`;
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         const repoToken = core.getInput("repoToken", { required: true });
@@ -7710,8 +7711,8 @@ function addLabelIfNotExists(label, { number }, { client }) {
             .catch((error) => {
             if ((error.status === 403 || error.status === 404) &&
                 error.message.endsWith(`Resource not accessible by integration`)) {
-                core.warning(`could not remove label`);
-                core.info(`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`);
+                core.warning(`could not add label "${label}"`);
+                core.info(commonErrorDetailedMessage);
             }
             else {
                 throw new Error(`error adding "${label}": ${error}`);
@@ -7725,8 +7726,8 @@ function removeLabelIfExists(label, { number }, { client }) {
         .catch((error) => {
         if ((error.status === 403 || error.status === 404) &&
             error.message.endsWith(`Resource not accessible by integration`)) {
-            core.warning(`could not remove label`);
-            core.info(`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`);
+            core.warning(`could not remove label "${label}"`);
+            core.info(commonErrorDetailedMessage);
         }
         else if (error.status !== 404) {
             throw new Error(`error removing "${label}": ${error}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -7608,6 +7608,7 @@ function main() {
         });
     });
 }
+const continueOnMissingPermissions = () => core.getInput("continueOnMissingPermissions") === "true" || false;
 function checkDirty(context) {
     return __awaiter(this, void 0, void 0, function* () {
         const { after, client, dirtyLabel, removeOnDirtyLabel, retryAfter, retryMax, } = context;
@@ -7724,6 +7725,7 @@ function addLabelIfNotExists(label, { number }, { client }) {
         })
             .catch((error) => {
             if ((error.status === 403 || error.status === 404) &&
+                continueOnMissingPermissions() &&
                 error.message.endsWith(`Resource not accessible by integration`)) {
                 core.warning(`could not add label "${label}": ${commonErrorDetailedMessage}`);
             }
@@ -7743,6 +7745,7 @@ function removeLabelIfExists(label, { number }, { client }) {
     })
         .catch((error) => {
         if ((error.status === 403 || error.status === 404) &&
+            continueOnMissingPermissions() &&
             error.message.endsWith(`Resource not accessible by integration`)) {
             core.warning(`could not remove label "${label}": ${commonErrorDetailedMessage}`);
         }

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -86,7 +86,8 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
 			//accept: "application/vnd.github.merge-info-preview+json"
 		},
 		after,
-		...getOwnerAndRepo(),
+		owner: github.context.repo.owner,
+		repo: github.context.repo.repo,
 	});
 
 	const {
@@ -169,7 +170,8 @@ async function addLabelIfNotExists(
 	{ client }: { client: GitHub }
 ) {
 	const { data: issue } = await client.issues.get({
-		...getOwnerAndRepo(),
+		owner: github.context.repo.owner,
+		repo: github.context.repo.repo,
 		issue_number: number,
 	});
 
@@ -188,7 +190,8 @@ async function addLabelIfNotExists(
 
 	await client.issues
 		.addLabels({
-			...getOwnerAndRepo(),
+			owner: github.context.repo.owner,
+			repo: github.context.repo.repo,
 			issue_number: number,
 			labels: [label],
 		})
@@ -212,7 +215,8 @@ function removeLabelIfExists(
 ) {
 	return client.issues
 		.removeLabel({
-			...getOwnerAndRepo(),
+			owner: github.context.repo.owner,
+			repo: github.context.repo.repo,
 			issue_number: number,
 			name: label,
 		})
@@ -231,16 +235,6 @@ function removeLabelIfExists(
 				);
 			}
 		});
-}
-function getOwnerAndRepo(): { owner: string; repo: string } {
-	if (github.context.issue) {
-		return {
-			repo: github.context.issue.repo,
-			owner: github.context.issue.owner,
-		};
-	} else {
-		return { repo: github.context.repo.repo, owner: github.context.repo.owner };
-	}
 }
 main().catch((error) => {
 	core.error(String(error));

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -200,8 +200,7 @@ async function addLabelIfNotExists(
 				(error.status === 403 || error.status === 404) &&
 				error.message.endsWith(`Resource not accessible by integration`)
 			) {
-				core.warning(`could not add label "${label}"`);
-				core.info(commonErrorDetailedMessage);
+				core.warning(`could not add label "${label}": ${commonErrorDetailedMessage}`);
 			} else {
 				throw new Error(`error adding "${label}": ${error}`);
 			}
@@ -225,8 +224,7 @@ function removeLabelIfExists(
 				(error.status === 403 || error.status === 404) &&
 				error.message.endsWith(`Resource not accessible by integration`)
 			) {
-				core.warning(`could not remove label "${label}"`);
-				core.info(commonErrorDetailedMessage);
+				core.warning(`could not remove label "${label}": ${commonErrorDetailedMessage}`);
 			} else if (error.status !== 404) {
 				throw new Error(`error removing "${label}": ${error}`);
 			} else {

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -85,8 +85,7 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
 			//accept: "application/vnd.github.merge-info-preview+json"
 		},
 		after,
-		owner: github.context.repo.owner,
-		repo: github.context.repo.repo,
+		...getOwnerAndRepo()
 	});
 
 	const {
@@ -169,8 +168,7 @@ async function addLabelIfNotExists(
 	{ client }: { client: GitHub }
 ) {
 	const { data: issue } = await client.issues.get({
-		owner: github.context.repo.owner,
-		repo: github.context.repo.repo,
+		...getOwnerAndRepo(),
 		issue_number: number,
 	});
 
@@ -189,8 +187,7 @@ async function addLabelIfNotExists(
 
 	await client.issues
 		.addLabels({
-			owner: github.context.repo.owner,
-			repo: github.context.repo.repo,
+			...getOwnerAndRepo(),
 			issue_number: number,
 			labels: [label],
 		})
@@ -206,8 +203,7 @@ function removeLabelIfExists(
 ) {
 	return client.issues
 		.removeLabel({
-			owner: github.context.repo.owner,
-			repo: github.context.repo.repo,
+			...getOwnerAndRepo(),
 			issue_number: number,
 			name: label,
 		})
@@ -221,7 +217,13 @@ function removeLabelIfExists(
 			}
 		});
 }
-
+function getOwnerAndRepo(): {owner: string, repo: string} {
+	if(github.context.issue) {
+		return { repo: github.context.issue.repo, owner: github.context.issue.owner };
+	} else {
+		return { repo: github.context.repo.repo, owner: github.context.repo.owner };
+	}
+}
 main().catch((error) => {
 	core.error(String(error));
 	core.setFailed(String(error.message));

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -85,7 +85,7 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
 			//accept: "application/vnd.github.merge-info-preview+json"
 		},
 		after,
-		...getOwnerAndRepo()
+		...getOwnerAndRepo(),
 	});
 
 	const {
@@ -192,9 +192,14 @@ async function addLabelIfNotExists(
 			labels: [label],
 		})
 		.catch((error) => {
-			if ((error.status === 403 || error.status === 404) && error.message.endsWith(`Resource not accessible by integration`)) {
+			if (
+				(error.status === 403 || error.status === 404) &&
+				error.message.endsWith(`Resource not accessible by integration`)
+			) {
 				core.warning(`could not remove label`);
-				core.info(`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`);
+				core.info(
+					`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`
+				);
 			} else {
 				throw new Error(`error adding "${label}": ${error}`);
 			}
@@ -213,9 +218,14 @@ function removeLabelIfExists(
 			name: label,
 		})
 		.catch((error) => {
-			if ((error.status === 403 || error.status === 404) && error.message.endsWith(`Resource not accessible by integration`)) {
+			if (
+				(error.status === 403 || error.status === 404) &&
+				error.message.endsWith(`Resource not accessible by integration`)
+			) {
 				core.warning(`could not remove label`);
-				core.info(`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`);
+				core.info(
+					`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`
+				);
 			} else if (error.status !== 404) {
 				throw new Error(`error removing "${label}": ${error}`);
 			} else {
@@ -225,9 +235,12 @@ function removeLabelIfExists(
 			}
 		});
 }
-function getOwnerAndRepo(): {owner: string, repo: string} {
-	if(github.context.issue) {
-		return { repo: github.context.issue.repo, owner: github.context.issue.owner };
+function getOwnerAndRepo(): { owner: string; repo: string } {
+	if (github.context.issue) {
+		return {
+			repo: github.context.issue.repo,
+			owner: github.context.issue.owner,
+		};
 	} else {
 		return { repo: github.context.repo.repo, owner: github.context.repo.owner };
 	}

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -26,6 +26,9 @@ async function main() {
 	});
 }
 
+const continueOnMissingPermissions = () =>
+	core.getInput("continueOnMissingPermissions") === "true" || false;
+
 interface CheckDirtyContext {
 	after: string | null;
 	client: GitHub;
@@ -198,9 +201,12 @@ async function addLabelIfNotExists(
 		.catch((error) => {
 			if (
 				(error.status === 403 || error.status === 404) &&
+				continueOnMissingPermissions() &&
 				error.message.endsWith(`Resource not accessible by integration`)
 			) {
-				core.warning(`could not add label "${label}": ${commonErrorDetailedMessage}`);
+				core.warning(
+					`could not add label "${label}": ${commonErrorDetailedMessage}`
+				);
 			} else {
 				throw new Error(`error adding "${label}": ${error}`);
 			}
@@ -222,9 +228,12 @@ function removeLabelIfExists(
 		.catch((error) => {
 			if (
 				(error.status === 403 || error.status === 404) &&
+				continueOnMissingPermissions() &&
 				error.message.endsWith(`Resource not accessible by integration`)
 			) {
-				core.warning(`could not remove label "${label}": ${commonErrorDetailedMessage}`);
+				core.warning(
+					`could not remove label "${label}": ${commonErrorDetailedMessage}`
+				);
 			} else if (error.status !== 404) {
 				throw new Error(`error removing "${label}": ${error}`);
 			} else {

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -192,7 +192,12 @@ async function addLabelIfNotExists(
 			labels: [label],
 		})
 		.catch((error) => {
-			throw new Error(`error adding "${label}": ${error}`);
+			if ((error.status === 403 || error.status === 404) && error.message.endsWith(`Resource not accessible by integration`)) {
+				core.warning(`could not remove label`);
+				core.info(`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`);
+			} else {
+				throw new Error(`error adding "${label}": ${error}`);
+			}
 		});
 }
 
@@ -208,7 +213,10 @@ function removeLabelIfExists(
 			name: label,
 		})
 		.catch((error) => {
-			if (error.status !== 404) {
+			if ((error.status === 403 || error.status === 404) && error.message.endsWith(`Resource not accessible by integration`)) {
+				core.warning(`could not remove label`);
+				core.info(`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`);
+			} else if (error.status !== 404) {
 				throw new Error(`error removing "${label}": ${error}`);
 			} else {
 				core.info(

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -3,6 +3,7 @@ import * as github from "@actions/github";
 
 type GitHub = ReturnType<typeof github.getOctokit>;
 const prDirtyStatusesOutputKey = `prDirtyStatuses`;
+const commonErrorDetailedMessage = `Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`;
 
 async function main() {
 	const repoToken = core.getInput("repoToken", { required: true });
@@ -196,10 +197,8 @@ async function addLabelIfNotExists(
 				(error.status === 403 || error.status === 404) &&
 				error.message.endsWith(`Resource not accessible by integration`)
 			) {
-				core.warning(`could not remove label`);
-				core.info(
-					`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`
-				);
+				core.warning(`could not add label "${label}"`);
+				core.info(commonErrorDetailedMessage);
 			} else {
 				throw new Error(`error adding "${label}": ${error}`);
 			}
@@ -222,10 +221,8 @@ function removeLabelIfExists(
 				(error.status === 403 || error.status === 404) &&
 				error.message.endsWith(`Resource not accessible by integration`)
 			) {
-				core.warning(`could not remove label`);
-				core.info(
-					`Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`
-				);
+				core.warning(`could not remove label "${label}"`);
+				core.info(commonErrorDetailedMessage);
 			} else if (error.status !== 404) {
 				throw new Error(`error removing "${label}": ${error}`);
 			} else {


### PR DESCRIPTION
As you can see in https://github.com/eps1lon/actions-label-merge-conflict/runs/890095723?check_suite_focus=true#step:9:7 the action fails when a PR which comes from a fork is updated (push to the source branch). 
It seems to be because in that case the github.context.repo reference points to the fork and not the upstream, making the subsequent queries wrong.
This pull request checks for the issue's information first (if any) and falls back on the repo information