### PR TITLE
feat: Only check PRs against push context ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## unreleased
+
+- Only update PRs based off of the branch in the `push` event
+  Previously we checked every open PR.
+  Since a `push` to a branch can only create merge conflicts with that branch we can limit the set of checked PRs.
+  This should help repositories with lots of PRs targetting different branches with rate limiting.
+
 ## 1.4.0
 
 - Allow warning only if secrets aren't available ([#22](https://github.com/eps1lon/actions-label-merge-conflict/pull/22) by @baywet)

--- a/dist/index.js
+++ b/dist/index.js
@@ -7606,7 +7606,7 @@ function main() {
         const retryAfter = parseInt(core.getInput("retryAfter") || "120", 10);
         const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
         const isPushEvent = process.env.GITHUB_EVENT_NAME === "push";
-        core.debug(`${process.env.GITHUB_EVENT_NAME} === "push" = ${String(isPushEvent)}`);
+        core.debug(`isPushEvent = ${process.env.GITHUB_EVENT_NAME} === "push"`);
         const baseRefName = isPushEvent ? getBranchName(github.context.ref) : null;
         const client = github.getOctokit(repoToken);
         yield checkDirty({

--- a/dist/index.js
+++ b/dist/index.js
@@ -7588,6 +7588,16 @@ const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
 const prDirtyStatusesOutputKey = `prDirtyStatuses`;
 const commonErrorDetailedMessage = `Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`;
+/**
+ * returns `null` if the ref isn't a branch but e.g. a tag
+ * @param ref
+ */
+function getBranchName(ref) {
+    if (ref.startsWith("refs/heads/")) {
+        return ref.replace(/^refs\/heads\//, "");
+    }
+    return null;
+}
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         const repoToken = core.getInput("repoToken", { required: true });
@@ -7595,8 +7605,12 @@ function main() {
         const removeOnDirtyLabel = core.getInput("removeOnDirtyLabel");
         const retryAfter = parseInt(core.getInput("retryAfter") || "120", 10);
         const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
+        const isPushEvent = process.env.GITHUB_EVENT_NAME === "push";
+        core.debug(`${process.env.GITHUB_EVENT_NAME} === "push" = ${String(isPushEvent)}`);
+        const baseRefName = isPushEvent ? getBranchName(github.context.ref) : null;
         const client = github.getOctokit(repoToken);
         yield checkDirty({
+            baseRefName,
             client,
             dirtyLabel,
             removeOnDirtyLabel,
@@ -7611,15 +7625,15 @@ const commentOnDirty = () => core.getInput("commentOnDirty");
 const commentOnClean = () => core.getInput("commentOnClean");
 function checkDirty(context) {
     return __awaiter(this, void 0, void 0, function* () {
-        const { after, client, dirtyLabel, removeOnDirtyLabel, retryAfter, retryMax, } = context;
+        const { after, baseRefName, client, dirtyLabel, removeOnDirtyLabel, retryAfter, retryMax, } = context;
         if (retryMax <= 0) {
             core.warning("reached maximum allowed retries");
             return {};
         }
         const query = `
-query openPullRequests($owner: String!, $repo: String!, $after: String) { 
+query openPullRequests($owner: String!, $repo: String!, $after: String, $baseRefName: String) { 
   repository(owner:$owner, name: $repo) { 
-    pullRequests(first:100, after:$after, states: OPEN) {
+    pullRequests(first: 100, after: $after, states: OPEN, baseRefName: $baseRefName) {
       nodes {
         mergeable
         number
@@ -7643,6 +7657,7 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
             //accept: "application/vnd.github.merge-info-preview+json"
             },
             after,
+            baseRefName,
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
         });

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -5,6 +5,17 @@ type GitHub = ReturnType<typeof github.getOctokit>;
 const prDirtyStatusesOutputKey = `prDirtyStatuses`;
 const commonErrorDetailedMessage = `Worflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)`;
 
+/**
+ * returns `null` if the ref isn't a branch but e.g. a tag
+ * @param ref
+ */
+function getBranchName(ref: string): string | null {
+	if (ref.startsWith("refs/heads/")) {
+		return ref.replace(/^refs\/heads\//, "");
+	}
+	return null;
+}
+
 async function main() {
 	const repoToken = core.getInput("repoToken", { required: true });
 	const dirtyLabel = core.getInput("dirtyLabel", { required: true });
@@ -12,9 +23,16 @@ async function main() {
 	const retryAfter = parseInt(core.getInput("retryAfter") || "120", 10);
 	const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
 
+	const isPushEvent = process.env.GITHUB_EVENT_NAME === "push";
+	core.debug(
+		`${process.env.GITHUB_EVENT_NAME} === "push" = ${String(isPushEvent)}`
+	);
+	const baseRefName = isPushEvent ? getBranchName(github.context.ref) : null;
+
 	const client = github.getOctokit(repoToken);
 
 	await checkDirty({
+		baseRefName,
 		client,
 		dirtyLabel,
 		removeOnDirtyLabel,
@@ -32,6 +50,7 @@ const commentOnClean = () => core.getInput("commentOnClean");
 
 interface CheckDirtyContext {
 	after: string | null;
+	baseRefName: string | null;
 	client: GitHub;
 	dirtyLabel: string;
 	removeOnDirtyLabel: string;
@@ -48,6 +67,7 @@ async function checkDirty(
 ): Promise<Record<number, boolean>> {
 	const {
 		after,
+		baseRefName,
 		client,
 		dirtyLabel,
 		removeOnDirtyLabel,
@@ -64,9 +84,9 @@ async function checkDirty(
 		repository: any;
 	}
 	const query = `
-query openPullRequests($owner: String!, $repo: String!, $after: String) { 
+query openPullRequests($owner: String!, $repo: String!, $after: String, $baseRefName: String) { 
   repository(owner:$owner, name: $repo) { 
-    pullRequests(first:100, after:$after, states: OPEN) {
+    pullRequests(first: 100, after: $after, states: OPEN, baseRefName: $baseRefName) {
       nodes {
         mergeable
         number
@@ -90,6 +110,7 @@ query openPullRequests($owner: String!, $repo: String!, $after: String) {
 			//accept: "application/vnd.github.merge-info-preview+json"
 		},
 		after,
+		baseRefName,
 		owner: github.context.repo.owner,
 		repo: github.context.repo.repo,
 	});

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -24,9 +24,7 @@ async function main() {
 	const retryMax = parseInt(core.getInput("retryMax") || "5", 10);
 
 	const isPushEvent = process.env.GITHUB_EVENT_NAME === "push";
-	core.debug(
-		`${process.env.GITHUB_EVENT_NAME} === "push" = ${String(isPushEvent)}`
-	);
+	core.debug(`isPushEvent = ${process.env.GITHUB_EVENT_NAME} === "push"`);
 	const baseRefName = isPushEvent ? getBranchName(github.context.ref) : null;
 
 	const client = github.getOctokit(repoToken);


### PR DESCRIPTION
Since a `push` to a branch can only create merge conflicts with that branch we can limit the set of checked PRs.

Marking as breaking to be safe.