### PR TITLE
test: Run action on Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: "16"
       - name: Install dependencies
         run: yarn
       - name: Format

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ ouputs:
   prDirtyStatuses:
     description: "Object-map. The keys are pull request numbers and their values whether a PR is dirty or not."
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 author: "Sebastian Silbermann"
 branding:


### PR DESCRIPTION
The change proposed executes the action with Node 16, rather than 12.

This proposal aligns with GitHub's policy of moving workflows: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Actions still running on Node 12 are labeled as deprecated on every workflow run:
![Screenshot 2022-10-12 at 09 13 26](https://user-images.githubusercontent.com/13383509/195274733-8e644d37-0b0a-4890-b29b-65a9194bc842.png)