### PR TITLE
Update Node.js to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: hmarr/debug-action@master
       - name: checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
       - name: Install dependencies
         run: yarn
       - name: Format

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ ouputs:
   prDirtyStatuses:
     description: "Object-map. The keys are pull request numbers and their values whether a PR is dirty or not."
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 author: "Sebastian Silbermann"
 branding:


### PR DESCRIPTION
The change proposed updates Node.js from 16 to 20 to address the GH action deprecation warning.
![Screenshot 2024-02-11 at 13 55 35](https://github.com/eps1lon/actions-label-merge-conflict/assets/13383509/a3088d88-8a86-496c-844d-55a85d1c1feb)

Fixes #114

I would appreciate a release after merge @eps1lon :)