### PR TITLE
chore: Remove debug-action from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@master
       - name: checkout
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
I believe this is now incorporated into GitHub by re-running with debug  info