### PR TITLE
fix: Handle error when label is not available

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29880,7 +29880,7 @@ function removeLabelIfExists(labelName_1, issue_1, _a) {
             .then(() => true, (error) => {
             if ((error.status === 403 || error.status === 404) &&
                 continueOnMissingPermissions() &&
-                error.message.endsWith(`Resource not accessible by integration`)) {
+                error.message.includes(`Resource not accessible by integration`)) {
                 core.warning(`could not remove label "${labelName}": ${commonErrorDetailedMessage}`);
             }
             else if (error.status !== 404) {

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -307,7 +307,7 @@ async function removeLabelIfExists(
 				if (
 					(error.status === 403 || error.status === 404) &&
 					continueOnMissingPermissions() &&
-					error.message.endsWith(`Resource not accessible by integration`)
+					error.message.includes(`Resource not accessible by integration`)
 				) {
 					core.warning(
 						`could not remove label "${labelName}": ${commonErrorDetailedMessage}`,


### PR DESCRIPTION
GitHub probably changed the error message to `HttpError: Resource not accessible by integration - https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue` so `endsWith` is not applicable here anymore.

Example: https://github.com/DefectDojo/django-DefectDojo/actions/runs/9013598123/workflow?pr=10095